### PR TITLE
fontawesome 업데이트

### DIFF
--- a/modules/board/skins/sketchbook5/__setting.html
+++ b/modules/board/skins/sketchbook5/__setting.html
@@ -162,7 +162,7 @@
 <!--@end-->
 
 <!--%load_js_plugin("ui")-->
-<load target="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" />
+<load target="https://cdn.jsdelivr.net/fontawesome/4.3.0/css/font-awesome.min.css" />
 <load target="css/board.css" />
 <load target="css/ie8.css" targetie="lt IE 9" />
 <load cond="$mi->colorset=='black'" target="css/black.css" />


### PR DESCRIPTION
fontawesome 업데이트.

bootstrapcdn의 경우 서버가 제일 가까운곳이 미국 이라서 느립니다. 무거운 폰트를 미국에서 불러오는것 보다는 한국에 캐시 서버가 있는 것을 사용하는게 나을것 같아서
jsdelivr로 변경해 보았습니다.
